### PR TITLE
Add WeChat scraper example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@ Check out the following resources to get started:
 - [x] **LLM Frameworks**: [Langchain (python)](https://python.langchain.com/docs/integrations/document_loaders/firecrawl/), [Langchain (js)](https://js.langchain.com/docs/integrations/document_loaders/web_loaders/firecrawl), [Llama Index](https://docs.llamaindex.ai/en/latest/examples/data_connectors/WebPageDemo/#using-firecrawl-reader), [Crew.ai](https://docs.crewai.com/), [Composio](https://composio.dev/tools/firecrawl/all), [PraisonAI](https://docs.praison.ai/firecrawl/), [Superinterface](https://superinterface.ai/docs/assistants/functions/firecrawl), [Vectorize](https://docs.vectorize.io/integrations/source-connectors/firecrawl)
 - [x] **Low-code Frameworks**: [Dify](https://dify.ai/blog/dify-ai-blog-integrated-with-firecrawl), [Langflow](https://docs.langflow.org/), [Flowise AI](https://docs.flowiseai.com/integrations/langchain/document-loaders/firecrawl), [Cargo](https://docs.getcargo.io/integration/firecrawl), [Pipedream](https://pipedream.com/apps/firecrawl/)
 - [x] **Others**: [Zapier](https://zapier.com/apps/firecrawl/integrations), [Pabbly Connect](https://www.pabbly.com/connect/integrations/firecrawl/)
+- [x] **Examples**: [WeChat public account scraper](examples/wechat_public_scraper) *(includes a helper script to test scraping)*
 - [ ] Want an SDK or Integration? Let us know by opening an issue.
 
 To run locally, refer to guide [here](https://github.com/mendableai/firecrawl/blob/main/CONTRIBUTING.md).
+
+### WeChat Public Account Scraper Example
+
+An example project for scraping WeChat articles is available in
+[examples/wechat_public_scraper](examples/wechat_public_scraper). It demonstrates
+how to provide custom headers when calling the Firecrawl API. After setting your
+`FIRECRAWL_API_KEY` (and optionally `WECHAT_URL`), you can run
+`test_wechat_scraper.py` in that directory to verify the scraper works with your
+credentials.
 
 ### API Key
 

--- a/examples/wechat_public_scraper/README.md
+++ b/examples/wechat_public_scraper/README.md
@@ -1,0 +1,27 @@
+# WeChat Public Account Scraper Example
+
+This example shows how to scrape the content of a WeChat public account article using the Firecrawl Python SDK.
+
+> **Note**: WeChat pages often implement anti-crawling measures and may require authentication. Success is not guaranteed. Always ensure that your use complies with WeChat's terms of service and privacy policy.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install firecrawl-py python-dotenv
+   ```
+2. Set your Firecrawl API key as `FIRECRAWL_API_KEY` in an `.env` file. Optionally provide the target article URL via `WECHAT_URL`.
+3. Run the script:
+   ```bash
+   python wechat_public_scraper.py
+   ```
+   The script will output the article content in Markdown if the request succeeds.
+
+## Testing
+
+For convenience, a helper script `test_wechat_scraper.py` is included to quickly
+verify that the scraper works with your environment variables:
+
+```bash
+python test_wechat_scraper.py
+```

--- a/examples/wechat_public_scraper/test_wechat_scraper.py
+++ b/examples/wechat_public_scraper/test_wechat_scraper.py
@@ -1,0 +1,10 @@
+"""Simple test runner for the WeChat Public Account scraper.
+
+Set `FIRECRAWL_API_KEY` in your environment and optionally `WECHAT_URL` to the
+article you want to scrape, then run this file to execute the scraper.
+"""
+from wechat_public_scraper import main
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wechat_public_scraper/wechat_public_scraper.py
+++ b/examples/wechat_public_scraper/wechat_public_scraper.py
@@ -1,0 +1,35 @@
+import os
+from dotenv import load_dotenv
+from firecrawl import FirecrawlApp
+
+load_dotenv()
+
+# Replace with the WeChat article URL you want to scrape
+WECHAT_URL = os.getenv("WECHAT_URL", "https://mp.weixin.qq.com/")
+
+
+def main():
+    app = FirecrawlApp(api_key=os.getenv("FIRECRAWL_API_KEY"))
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) "
+            "AppleWebKit/604.1.38 (KHTML, like Gecko) Version/12.0 "
+            "Mobile/15A372 Safari/604.1"
+        )
+    }
+
+    data = app.scrape_url(
+        WECHAT_URL,
+        formats=["markdown", "html"],
+        headers=headers,
+    )
+
+    if data.success:
+        print(data.markdown)
+    else:
+        print(f"Error: {data.error}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update root README with details on WeChat example and testing
- document test runner for the WeChat scraper example
- add `test_wechat_scraper.py` helper script

## Testing
- `npm run test:local-no-auth` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `pytest` *(fails: ModuleNotFoundError for firecrawl and dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6840091e9f84832d9ad2f2af0a034fd7